### PR TITLE
Update project to dotnet 8

### DIFF
--- a/HttpHandler/HttpHandler.csproj
+++ b/HttpHandler/HttpHandler.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+	  <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/HttpWebRequestExecutor/HttpWebRequestExecutor.csproj
+++ b/HttpWebRequestExecutor/HttpWebRequestExecutor.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+	  <TargetFramework>net8.0</TargetFramework>
     <Authors>Ryan Johnson</Authors>
     <Copyright>Copyright 2019</Copyright>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
@@ -14,7 +14,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="SharpZipLib" Version="1.1.0" />
+    <PackageReference Include="SharpZipLib" Version="1.4.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Tests/HttpWebRequestBuilderTests.cs
+++ b/Tests/HttpWebRequestBuilderTests.cs
@@ -8,6 +8,7 @@ using HttpParser.Models;
 using HttpWebRequestExecutor.Models;
 using Tests.FakeData;
 using HttpWebRequestExecutor.Interfaces;
+using FluentAssertions;
 
 namespace Tests
 {
@@ -20,7 +21,7 @@ namespace Tests
             var parsed = Parser.ParseRawRequest(FakeRawRequests.GetWithoutQueryString);
             var req = HttpWebRequestBuilder.InitializeWebRequest(parsed);
 
-            Assert.AreEqual("System.Net.HttpWebRequest", req.GetType().ToString());
+            req.Should().BeOfType<System.Net.HttpWebRequest>();
         }
 
         [Test]
@@ -54,7 +55,7 @@ namespace Tests
             }
 
             // assert
-            Assert.AreEqual(expected, actual);
+            actual.Should().Be(expected);
         }
 
         [Test]
@@ -85,7 +86,7 @@ namespace Tests
             }
 
             // assert
-            Assert.AreEqual(expected, actual);
+            actual.Should().BeEquivalentTo(expected);
         }
 
         private static MemoryStream FakeStream(string expected)

--- a/Tests/ParseRawHttpTests.cs
+++ b/Tests/ParseRawHttpTests.cs
@@ -1,4 +1,5 @@
-﻿using HttpParser;
+﻿using FluentAssertions;
+using HttpParser;
 using HttpParser.Models;
 using NUnit.Framework;
 using Tests.FakeData;
@@ -12,10 +13,9 @@ namespace HttpParserTests
         public void Should_Parse_Get()
         {
             var parsed = Parser.ParseRawRequest(FakeRawRequests.GetWithoutQueryString);
-
-            Assert.AreEqual("https://httpbin.org/get", parsed.Url);
-            Assert.AreEqual("GET", parsed.Headers["Method"]);
-            Assert.AreEqual(null, parsed.RequestBody);
+            parsed.Url.Should().BeEquivalentTo("https://httpbin.org/get");
+            parsed.Headers["Method"].Should().BeEquivalentTo("GET");
+            parsed.RequestBody.Should().BeNull();
         }
 
         [Test]
@@ -23,9 +23,9 @@ namespace HttpParserTests
         {
             var parsed = Parser.ParseRawRequest(FakeRawRequests.GetWithQueryString);
 
-            Assert.AreEqual("https://httpbin.org/get?name=ryan", parsed.Url);
-            Assert.AreEqual("GET", parsed.Headers["Method"]);
-            Assert.AreEqual("name=ryan", parsed.RequestBody);
+            parsed.Url.Should().BeEquivalentTo("https://httpbin.org/get?name=ryan");
+            parsed.Headers["Method"].Should().BeEquivalentTo("GET");
+            parsed.RequestBody.Should().BeEquivalentTo("name=ryan");
         }
 
         [Test]
@@ -38,9 +38,9 @@ namespace HttpParserTests
 
             var parsed = Parser.ParseRawRequest(FakeRawRequests.GetWithQueryString, options);
 
-            Assert.AreEqual("https://httpbin.org/get?name=ryan", parsed.Url);
-            Assert.AreEqual("GET", parsed.Headers["Method"]);
-            Assert.AreEqual(null, parsed.RequestBody);
+            parsed.Url.Should().BeEquivalentTo("https://httpbin.org/get?name=ryan");
+            parsed.Headers["Method"].Should().BeEquivalentTo("GET");
+            parsed.RequestBody.Should().BeNull();
         }
 
         [Test]
@@ -48,9 +48,9 @@ namespace HttpParserTests
         {
             var parsed = Parser.ParseRawRequest(FakeRawRequests.PostWithRequestBody);
 
-            Assert.AreEqual("https://httpbin.org/post", parsed.Url);
-            Assert.AreEqual("POST", parsed.Headers["Method"]);
-            Assert.AreEqual("helloworld", parsed.RequestBody);
+            parsed.Url.Should().BeEquivalentTo("https://httpbin.org/post");
+            parsed.Headers["Method"].Should().BeEquivalentTo("POST");
+            parsed.RequestBody.Should().BeEquivalentTo("helloworld");
         }
 
         [Test]
@@ -63,11 +63,11 @@ namespace HttpParserTests
 
             var parsed = Parser.ParseRawRequest(FakeRawRequests.PostWithRequestBody, options);
 
-            Assert.AreEqual("https://httpbin.org/post", parsed.Url);
-            Assert.AreEqual("POST", parsed.Headers["Method"]);
-            Assert.AreEqual(1, parsed.Cookies.Count);
-            Assert.AreEqual("chocchip", parsed.Cookies["ilikecookies"]);
-            Assert.AreEqual(null, parsed.RequestBody);
+            parsed.Url.Should().BeEquivalentTo("https://httpbin.org/post");
+            parsed.Headers["Method"].Should().BeEquivalentTo("POST");
+            parsed.Cookies.Should().HaveCount(1);
+            parsed.Cookies["ilikecookies"].Should().BeEquivalentTo("chocchip");
+            parsed.RequestBody.Should().BeNull();
         }
 
         [TestCase(FakeRawRequests.BadlyFormattedRequest1, "URL is not in a valid format Method: SetUrl() Data: www.httpbin.org/get")]
@@ -75,7 +75,7 @@ namespace HttpParserTests
         {
             var ex = Assert.Throws<CouldNotParseHttpRequestException>(() => Parser.ParseRawRequest(raw));
 
-            Assert.AreEqual(expectedMessage, ex.Message);
+            ex.Message.Should().Be(expectedMessage);
         }
 
         [Test]

--- a/Tests/ParsedObjectConvertTests.cs
+++ b/Tests/ParsedObjectConvertTests.cs
@@ -1,5 +1,4 @@
-﻿using FluentAssertions;
-using NUnit.Framework;
+﻿using NUnit.Framework;
 
 namespace Tests
 {
@@ -12,15 +11,15 @@ namespace Tests
         {
             var parsed = HttpParser.Parser.ParseRawRequest(input);
 
-            parsed.ToString().Should().Be(input);
+            Assert.AreEqual(input, parsed.ToString());
         }
 
         [TestCase(FakeData.FakeRawRequests.PostWithRequestBody)]
         public void Should_Strip_Cookies(string input)
         {
             var parsed = HttpParser.Parser.ParseRawRequest(input, new HttpParser.Models.IgnoreHttpParserOptions { IgnoreCookies = true }); ;
-            
-            parsed.ToString().Should().BeEquivalentTo(requestCookiesStripped);
+
+            Assert.AreEqual(requestCookiesStripped, parsed.ToString());
         }
 
         private string requestCookiesStripped = @"POST https://httpbin.org/post HTTP/1.1

--- a/Tests/ParsedObjectConvertTests.cs
+++ b/Tests/ParsedObjectConvertTests.cs
@@ -1,4 +1,5 @@
-﻿using NUnit.Framework;
+﻿using FluentAssertions;
+using NUnit.Framework;
 
 namespace Tests
 {
@@ -11,7 +12,7 @@ namespace Tests
         {
             var parsed = HttpParser.Parser.ParseRawRequest(input);
 
-            Assert.AreEqual(input, parsed.ToString());
+            parsed.ToString().Should().Be(input);
         }
 
         [TestCase(FakeData.FakeRawRequests.PostWithRequestBody)]
@@ -19,7 +20,7 @@ namespace Tests
         {
             var parsed = HttpParser.Parser.ParseRawRequest(input, new HttpParser.Models.IgnoreHttpParserOptions { IgnoreCookies = true }); ;
             
-            Assert.AreEqual(requestCookiesStripped, parsed.ToString());
+            parsed.ToString().Should().BeEquivalentTo(requestCookiesStripped);
         }
 
         private string requestCookiesStripped = @"POST https://httpbin.org/post HTTP/1.1

--- a/Tests/RequestLineTests.cs
+++ b/Tests/RequestLineTests.cs
@@ -1,6 +1,6 @@
 ﻿using HttpParser.Models;
 using NUnit.Framework;
-
+using FluentAssertions;
 namespace HttpParserTests
 {
     [TestFixture]
@@ -13,9 +13,9 @@ namespace HttpParserTests
 
             var requestLine = new RequestLine(line);
 
-            Assert.AreEqual("GET", requestLine.Method);
-            Assert.AreEqual("https://www.example.com", requestLine.Url);
-            Assert.AreEqual("HTTP/1.1", requestLine.HttpVersion);
+            requestLine.Method.Should().BeEquivalentTo("GET");
+            requestLine.Url.Should().BeEquivalentTo("https://www.example.com");
+            requestLine.HttpVersion.Should().BeEquivalentTo("HTTP/1.1");
         }
 
         [Test]
@@ -24,7 +24,7 @@ namespace HttpParserTests
             var line = new[] { "PUT https://www.example.com HTTP/1.1" };
 
             var ex = Assert.Throws<CouldNotParseHttpRequestException>(() => new RequestLine(line));
-            Assert.AreEqual("Not a valid HTTP Verb Method: SetHttpMethod() Data: PUT", ex.Message);
+            ex.Message.Should().BeEquivalentTo("Not a valid HTTP Verb Method: SetHttpMethod() Data: PUT");
         }
 
         [Test]
@@ -33,7 +33,7 @@ namespace HttpParserTests
             var line = new[] { "GET www.example.com HTTP/1.1" };
 
             var ex = Assert.Throws<CouldNotParseHttpRequestException>(() => new RequestLine(line));
-            Assert.AreEqual("URL is not in a valid format Method: SetUrl() Data: www.example.com", ex.Message);
+            ex.Message.Should().BeEquivalentTo("URL is not in a valid format Method: SetUrl() Data: www.example.com");
         }
     }
 }

--- a/Tests/Tests.csproj
+++ b/Tests/Tests.csproj
@@ -2,14 +2,15 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+	  <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
-    <PackageReference Include="Moq" Version="4.12.0" />
-    <PackageReference Include="NUnit" Version="3.12.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.13.0" />
+    <PackageReference Include="FluentAssertions" Version="6.12.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
+    <PackageReference Include="Moq" Version="4.20.70" />
+    <PackageReference Include="NUnit" Version="4.1.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Updated dotnet to version 8 and all libraries used in the project. 
Rewritten part of the tests using FluentAssertions, except ParsedObjectConvertTests remained unchanged, because there is an error with the final size.